### PR TITLE
Improve accuracy when multiple path entries match

### DIFF
--- a/lib/open_api_parser/specification/root.rb
+++ b/lib/open_api_parser/specification/root.rb
@@ -25,8 +25,9 @@ module OpenApiParser
           if !method_details.nil?
             return Endpoint.new(path_details.first, method_details.first, method_details.last)
           end
-
         end
+
+        return nil
 
       rescue URI::InvalidURIError
         nil

--- a/lib/open_api_parser/specification/root.rb
+++ b/lib/open_api_parser/specification/root.rb
@@ -11,19 +11,23 @@ module OpenApiParser
         uri = URI.parse(path)
         requested_path = uri.path.gsub(/\..+\z/, "")
 
-        path_details = @raw["paths"].detect do |path_name, path|
+        matching_paths = @raw["paths"].select do |path_name, path|
           requested_path =~ to_pattern(path_name)
         end
-        return nil if path_details.nil?
+        return nil if matching_paths.empty?
 
-        path = path_details.last
+        matching_paths.each do |path_details|
+          path = path_details.last
 
-        method_details = path.detect do |method, schema|
-          method.to_s == request_method.downcase
+          method_details = path.detect do |method, schema|
+            method.to_s == request_method.downcase
+          end
+          if !method_details.nil?
+            return Endpoint.new(path_details.first, method_details.first, method_details.last)
+          end
+
         end
-        return nil if method_details.nil?
 
-        Endpoint.new(path_details.first, method_details.first, method_details.last)
       rescue URI::InvalidURIError
         nil
       end

--- a/spec/open_api_parser/specification/root_spec.rb
+++ b/spec/open_api_parser/specification/root_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe OpenApiParser::Specification::Root do
 
       expect(endpoint).to be_nil
     end
+
+    it "matches the expected path/operation when paths have significant components in common" do
+      endpoint = root.endpoint("/animals/search", "post")
+
+      expect(endpoint.raw.fetch("operationId")).to eq("searchAnimals")
+    end
   end
 
   describe "raw" do

--- a/spec/open_api_parser/specification/root_spec.rb
+++ b/spec/open_api_parser/specification/root_spec.rb
@@ -44,6 +44,11 @@ RSpec.describe OpenApiParser::Specification::Root do
 
       expect(endpoint.raw.fetch("operationId")).to eq("searchAnimals")
     end
+
+    it "handles a missing method on a valid URL" do
+      endpoint = root.endpoint("/headers", "head")
+      expect(endpoint).to be_nil
+    end
   end
 
   describe "raw" do

--- a/spec/resources/example_spec.yaml
+++ b/spec/resources/example_spec.yaml
@@ -29,6 +29,16 @@ definitions:
         enum:
           - ok
 
+  searchResponse:
+    required:
+      - name
+      - legs
+    properties:
+      name:
+        type: string
+      legs:
+        type: integer
+
   errorResponse:
     required:
       - status
@@ -109,6 +119,24 @@ paths:
           schema:
             $ref: "/definitions/errorResponse"
 
+  /animals/search:
+    post:
+      operationId: searchAnimals
+      parameters:
+        - name: name
+          in: body
+          required: true
+          type: string
+      responses:
+        200:
+          description: Search results
+          schema:
+            $ref: "/definitions/searchResponse"
+        default:
+          description: Error response
+          schema:
+            $ref: "/definitions/errorResponse"
+ 
   /people/{id}:
     get:
       operationId: getPerson


### PR DESCRIPTION
It's possible to write a spec with endpoints such that a given endpoint
path might match two or more of the spec's path entries. In the example
spec, I've added an `/animals/search` endpoint in addition to
`/animals/{id}`. One supports POST, the other GET.

These SHOULD be unambiguous to `specification.endpoint`, which takes
both a path and a method. However, it makes the routing decision
entirely based on the path and then only looks for a method to confirm
it found a match.

This leads to nil answers from queries like
`specification.endpoint('/animals/search', 'POST')`, that should return
valid data. By switching from a detect to a select, and examining all
potentially valid paths for the supported method, I eliminate this
false negative.