### PR TITLE
Bring header validation into line with spec

### DIFF
--- a/lib/open_api_parser/specification/endpoint.rb
+++ b/lib/open_api_parser/specification/endpoint.rb
@@ -60,7 +60,6 @@ module OpenApiParser
 
         permissive_schema.tap do |schema|
           schema["properties"] = header_properties
-          schema["required"] = header_properties.keys
         end
       end
 

--- a/lib/open_api_parser/version.rb
+++ b/lib/open_api_parser/version.rb
@@ -1,3 +1,3 @@
 module OpenApiParser
-  VERSION = "1.1.2"
+  VERSION = "1.2.0"
 end

--- a/spec/open_api_parser/specification/endpoint_spec.rb
+++ b/spec/open_api_parser/specification/endpoint_spec.rb
@@ -186,7 +186,6 @@ RSpec.describe OpenApiParser::Specification::Root do
 
       expect(endpoint.response_header_schema(200)).to eq({
         "additionalProperties" => true,
-        "required" => ["X_MY_HEADER"],
         "properties" => {
           "X_MY_HEADER" => {
             "type" => "string",
@@ -201,7 +200,6 @@ RSpec.describe OpenApiParser::Specification::Root do
 
       expect(endpoint.response_header_schema("200")).to eq({
         "additionalProperties" => true,
-        "required" => ["X_MY_HEADER"],
         "properties" => {
           "X_MY_HEADER" => {
             "type" => "string",


### PR DESCRIPTION
The OpenAPI specification says that the Headers object on a response
represents headers that *CAN* be specified with the response. The parser
treats header entries as required, which is not inline with the
specification.

This patch relaxes the behavior, and bumps the version of the Gem to
reflect the fact that it may be a breaking change for some workflows.
Tests that previously assumed headers were required have been modified
to reflect the new behavior.