### PR TITLE
Use `Addressable::URI.unencode` instead of obsoleted `URI.decode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.1
+
+* Use `Addressable::URI.unencode` instead of obsoleted `URI.decode`
+
 ## 1.2.0
 
 * Make all response headers optional

--- a/lib/open_api_parser.rb
+++ b/lib/open_api_parser.rb
@@ -2,6 +2,7 @@ require "json"
 require "uri"
 require "yaml"
 
+require "addressable/uri"
 require "json_schema"
 
 require "open_api_parser/document"

--- a/lib/open_api_parser/pointer.rb
+++ b/lib/open_api_parser/pointer.rb
@@ -16,7 +16,7 @@ module OpenApiParser
 
     def escaped_pointer
       if @raw_pointer.start_with?("#")
-        URI.decode(@raw_pointer[1..-1])
+        Addressable::URI.unencode(@raw_pointer[1..-1])
       else
         @raw_pointer
       end

--- a/lib/open_api_parser/version.rb
+++ b/lib/open_api_parser/version.rb
@@ -1,3 +1,3 @@
 module OpenApiParser
-  VERSION = "1.2.0"
+  VERSION = "1.2.1".freeze
 end

--- a/open_api_parser.gemspec
+++ b/open_api_parser.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = "~> 2.0"
 
+  spec.add_dependency "addressable", "~> 2.3"
   spec.add_dependency "json_schema", "~> 0.15.0"
 
   spec.add_development_dependency "bundler", "~> 1.13"


### PR DESCRIPTION
with ruby 2.4.1 `URI.decode` (aka `unescape`) yields the following warnings:
```
escaped_pointer: warning: URI.unescape is obsolete
```

`Addressable::URI.unencode` looks like the closest replacement.
Bumped to 1.3 because of the new dependency on addressable.