### PR TITLE
Use json-schema gem instead of json_schema

### DIFF
--- a/lib/open_api_parser.rb
+++ b/lib/open_api_parser.rb
@@ -3,7 +3,7 @@ require "uri"
 require "yaml"
 
 require "addressable/uri"
-require "json_schema"
+require "json-schema"
 
 require "open_api_parser/document"
 require "open_api_parser/file_cache"

--- a/lib/open_api_parser/specification.rb
+++ b/lib/open_api_parser/specification.rb
@@ -7,7 +7,7 @@ module OpenApiParser
 
       if validate_meta_schema
         meta_schema = JSON.parse(File.read(META_SCHEMA_PATH))
-        JsonSchema.parse!(meta_schema).validate!(raw_specification)
+        JSON::Validator.validate!(meta_schema, raw_specification)
       end
 
       OpenApiParser::Specification::Root.new(raw_specification)

--- a/open_api_parser.gemspec
+++ b/open_api_parser.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = "~> 2.0"
 
   spec.add_dependency "addressable", "~> 2.3"
-  spec.add_dependency "json-schema", "~> 2.8.0"
+  spec.add_dependency "json-schema", "~> 2.8"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/open_api_parser.gemspec
+++ b/open_api_parser.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = "~> 2.0"
 
   spec.add_dependency "addressable", "~> 2.3"
-  spec.add_dependency "json_schema", "~> 0.15.0"
+  spec.add_dependency "json-schema", "~> 2.8.0"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/open_api_parser/specification/endpoint_spec.rb
+++ b/spec/open_api_parser/specification/endpoint_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe OpenApiParser::Specification::Root do
   def root
     @root ||= begin
-      path = File.expand_path("../../../resources/example_spec.yaml", __FILE__)
+      path = File.expand_path("../../../resources/valid_spec.yaml", __FILE__)
       OpenApiParser::Specification.resolve(path)
     end
   end

--- a/spec/open_api_parser/specification/endpoint_spec.rb
+++ b/spec/open_api_parser/specification/endpoint_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe OpenApiParser::Specification::Root do
       endpoint = root.endpoint("/animals", "post")
 
       expect(endpoint.body_schema).to eq({
+        "type" => "object",
         "required" => ["name", "legs"],
         "properties" => {
           "name" => {
@@ -123,6 +124,7 @@ RSpec.describe OpenApiParser::Specification::Root do
       endpoint = root.endpoint("/animals", "post")
 
       expect(endpoint.response_body_schema(201)).to eq({
+        "type" => "object",
         "properties" => {
           "status" => {
             "type" => "string",
@@ -137,6 +139,7 @@ RSpec.describe OpenApiParser::Specification::Root do
       endpoint = root.endpoint("/animals", "post")
 
       expect(endpoint.response_body_schema("201")).to eq({
+        "type" => "object",
         "properties" => {
           "status" => {
             "type" => "string",
@@ -151,6 +154,7 @@ RSpec.describe OpenApiParser::Specification::Root do
       endpoint = root.endpoint("/animals", "post")
 
       expect(endpoint.response_body_schema(400)).to eq({
+        "type" => "object",
         "properties" => {
           "status" => {
             "type" => "string",

--- a/spec/open_api_parser/specification/root_spec.rb
+++ b/spec/open_api_parser/specification/root_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe OpenApiParser::Specification::Root do
   def root
     @root ||= begin
-      path = File.expand_path("../../../resources/example_spec.yaml", __FILE__)
+      path = File.expand_path("../../../resources/valid_spec.yaml", __FILE__)
       OpenApiParser::Specification.resolve(path)
     end
   end

--- a/spec/open_api_parser/specification_spec.rb
+++ b/spec/open_api_parser/specification_spec.rb
@@ -2,25 +2,42 @@ require "spec_helper"
 
 RSpec.describe OpenApiParser::Specification do
   describe "self.resolve" do
-    it "resolves a valid specification" do
-      path = File.expand_path("../../resources/example_spec.yaml", __FILE__)
-      specification = OpenApiParser::Specification.resolve(path)
+    context "valid specification" do
+      it "resolves successfully" do
+        path = File.expand_path("../../resources/valid_spec.yaml", __FILE__)
+        specification = OpenApiParser::Specification.resolve(path)
 
-      expect(specification.raw.fetch("swagger")).to eq("2.0")
+        expect(specification.raw.fetch("swagger")).to eq("2.0")
+      end
+
+      it "allows skipping meta schema validation" do
+        expect do
+          path = File.expand_path("../../resources/pointer_example.yaml", __FILE__)
+          OpenApiParser::Specification.resolve(path, validate_meta_schema: false)
+        end.to_not raise_error
+      end
     end
 
-    it "fails on an invalid specification" do
-      expect do
-        path = File.expand_path("../../resources/pointer_example.yaml", __FILE__)
-        OpenApiParser::Specification.resolve(path)
-      end.to raise_error(JsonSchema::Error)
-    end
+    context "invalid specification" do
+      it "fails to resolve if required properties are not set" do
+        expect do
+          path = File.expand_path("../../resources/pointer_example.yaml", __FILE__)
+          OpenApiParser::Specification.resolve(path)
+        end.to raise_error(
+          JSON::Schema::ValidationError,
+          /did not contain a required property of \'swagger\'/
+        )
+      end
 
-    it "allows skipping meta schema validation" do
-      expect do
-        path = File.expand_path("../../resources/pointer_example.yaml", __FILE__)
-        OpenApiParser::Specification.resolve(path, validate_meta_schema: false)
-      end.to_not raise_error
+      it "fails to resolve if nested validation rules are not met" do
+        expect do
+          path = File.expand_path("../../resources/invalid_spec.yaml", __FILE__)
+          OpenApiParser::Specification.resolve(path)
+        end.to raise_error(
+          JSON::Schema::ValidationError,
+          /contains additional properties \[\"fake-http-method\"\] outside of the schema/
+        )
+      end
     end
   end
 end

--- a/spec/resources/invalid_spec.yaml
+++ b/spec/resources/invalid_spec.yaml
@@ -1,0 +1,50 @@
+swagger: "2.0"
+
+info:
+  title: Simple API overview
+  version: "1"
+
+produces:
+  - application/json
+consumes:
+  - application/json
+
+definitions:
+  validResponse:
+    type: object
+    required:
+      - status
+    properties:
+      status:
+        type: string
+        enum:
+          - ok
+
+  errorResponse:
+    type: object
+    required:
+      - status
+    properties:
+      status:
+        type: string
+        enum:
+          - bad
+
+paths:
+  /animals/{id}:
+    fake-http-method:
+      operationId: fakeHttpMethod
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: integer
+      responses:
+        200:
+          description: Valid create
+          schema:
+            $ref: "#/definitions/validResponse"
+        default:
+          description: Error response
+          schema:
+            $ref: "#/definitions/errorResponse"

--- a/spec/resources/valid_spec.yaml
+++ b/spec/resources/valid_spec.yaml
@@ -2,7 +2,7 @@ swagger: "2.0"
 
 info:
   title: Simple API overview
-  version: 1
+  version: "1"
 
 produces:
   - application/json
@@ -11,6 +11,7 @@ consumes:
 
 definitions:
   createAnimal:
+    type: object
     required:
       - name
       - legs
@@ -21,6 +22,7 @@ definitions:
         type: integer
 
   validResponse:
+    type: object
     required:
       - status
     properties:
@@ -29,7 +31,16 @@ definitions:
         enum:
           - ok
 
+  createSearch:
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        type: string
+
   searchResponse:
+    type: object
     required:
       - name
       - legs
@@ -40,6 +51,7 @@ definitions:
         type: integer
 
   errorResponse:
+    type: object
     required:
       - status
     properties:
@@ -57,16 +69,16 @@ paths:
           in: body
           required: true
           schema:
-            $ref: "/definitions/createAnimal"
+            $ref: "#/definitions/createAnimal"
       responses:
         201:
           description: Valid create
           schema:
-            $ref: "/definitions/validResponse"
+            $ref: "#/definitions/validResponse"
         default:
           description: Error response
           schema:
-            $ref: "/definitions/errorResponse"
+            $ref: "#/definitions/errorResponse"
 
   /animals/{id}:
     get:
@@ -97,13 +109,13 @@ paths:
           type: integer
       responses:
         200:
-          description: Valid create
+          description: Valid get animal
           schema:
-            $ref: "/definitions/validResponse"
+            $ref: "#/definitions/validResponse"
         default:
           description: Error response
           schema:
-            $ref: "/definitions/errorResponse"
+            $ref: "#/definitions/errorResponse"
     delete:
       operationId: deleteAnimal
       parameters:
@@ -113,30 +125,31 @@ paths:
           type: integer
       responses:
         204:
-          description: Valid create
+          description: Valid delete
         default:
           description: Error response
           schema:
-            $ref: "/definitions/errorResponse"
+            $ref: "#/definitions/errorResponse"
 
   /animals/search:
     post:
       operationId: searchAnimals
       parameters:
-        - name: name
+        - name: body
           in: body
           required: true
-          type: string
+          schema:
+            $ref: "#/definitions/createSearch"
       responses:
         200:
           description: Search results
           schema:
-            $ref: "/definitions/searchResponse"
+            $ref: "#/definitions/searchResponse"
         default:
           description: Error response
           schema:
-            $ref: "/definitions/errorResponse"
- 
+            $ref: "#/definitions/errorResponse"
+
   /people/{id}:
     get:
       operationId: getPerson
@@ -147,22 +160,22 @@ paths:
           type: string
       responses:
         200:
-          description: Valid create
+          description: Valid get person
           schema:
-            $ref: "/definitions/validResponse"
+            $ref: "#/definitions/validResponse"
         default:
           description: Error response
           schema:
-            $ref: "/definitions/errorResponse"
+            $ref: "#/definitions/errorResponse"
 
   /headers:
     get:
       operationId: getHeaders
       responses:
         200:
-          description: Valid create
+          description: Valid get headers
           schema:
-            $ref: "/definitions/validResponse"
+            $ref: "#/definitions/validResponse"
           headers:
             X-My-Header:
               type: string


### PR DESCRIPTION
Inspired by https://github.com/braintree/open_api_parser/issues/7 and in response to the `json_schema` gem not properly validating nested objects, this PR switches the [json_schema](https://github.com/brandur/json_schema) gem with the [json-schema](https://github.com/ruby-json-schema/json-schema) gem.

We found this issue when there was an OpenAPI spec file with an invalid HTTP method type. 
```
paths:
  /animals:
    fake-http-method:
```
Despite the spec defining the allowed values in [/resources/swagger_meta_schema.json#L306-L343](https://github.com/braintree/open_api_parser/blob/91a668382bab53a037ffd913ddcd94ef691fc3c8/resources/swagger_meta_schema.json#L306-L343), those rules were not being enforced by the `json_schema` gem and the invalid spec was considered valid. Using the `json-schema` gem, validation was performed properly:
> The property '#/paths//animals' contains additional properties ["fake-http-method"] outside of the schema when none are allowed in schema

Also, fixed some of the descriptions in `valid_spec.yaml` that were copy pasted.

@drewolson @jfeltesse-mdsol @jcarres-mdsol @ykitamura-mdsol


