### PR TITLE
Expose Endpoint's path and method

### DIFF
--- a/lib/open_api_parser/specification/endpoint.rb
+++ b/lib/open_api_parser/specification/endpoint.rb
@@ -8,6 +8,8 @@ module OpenApiParser
         "required"
       ]
 
+      attr_reader :path
+      attr_reader :method
       attr_reader :raw
 
       def initialize(path, method, raw)

--- a/spec/open_api_parser/specification/endpoint_spec.rb
+++ b/spec/open_api_parser/specification/endpoint_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe OpenApiParser::Specification::Root do
+RSpec.describe OpenApiParser::Specification::Endpoint do
   def root
     @root ||= begin
       path = File.expand_path("../../../resources/valid_spec.yaml", __FILE__)

--- a/spec/open_api_parser/specification/endpoint_spec.rb
+++ b/spec/open_api_parser/specification/endpoint_spec.rb
@@ -8,6 +8,20 @@ RSpec.describe OpenApiParser::Specification::Endpoint do
     end
   end
 
+  describe "path" do
+    it "returns the path of the matched operation item" do
+      endpoint = root.endpoint("/animals/1", "get")
+      expect(endpoint.path).to eq "/animals/{id}"
+    end
+  end
+
+  describe "method" do
+    it "returns the method of the matched operation item" do
+      endpoint = root.endpoint("/animals", "POST")
+      expect(endpoint.method).to eq "post"
+    end
+  end
+
   describe "body_schema" do
     it "returns the schema for the body" do
       endpoint = root.endpoint("/animals", "post")


### PR DESCRIPTION
(This is a smaller PR :)

Motivation: it's useful to have access to the path of a matched Endpoint in OpenAPI notation.

Example: my current use case is providing developers with a snippet of a path item that they can copy/paste into openapi.yaml. In illustrative code:

```ruby
endpoint = root.endpoint("/pet/1", "get")
unless response.described_in? endpoint
  puts "please add a response object to the path below"
  puts {
    paths: {
      endpoint.path => {
        endpoint.method => response_template(response)
      }
    }
  }.to_yaml
end
```