### PR TITLE
Fix issue with matching substring references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,10 @@
 # Changelog
 
-## 1.3.1
-
-* Fix issue where references that matched a substring of the path were not being resolved
-  (e.g. "/definitions/PersonInfo" in "/definitions/PersonInfoResponse/schema")
-
 ## 1.3.0-dev
 
 * Expose `path` and `method` on endpoints
+* Fix issue where references that matched a substring of the path were not being resolved
+  (e.g. "/definitions/PersonInfo" in "/definitions/PersonInfoResponse/schema")
 
 ## 1.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.1
+
+* Fix issue where references that matched a substring of the path were not being resolved
+  (e.g. "/definitions/PersonInfo" in "/definitions/PersonInfoResponse/schema")
+
 ## 1.3.0-dev
 
 * Expose `path` and `method` on endpoints

--- a/lib/open_api_parser/pointer.rb
+++ b/lib/open_api_parser/pointer.rb
@@ -13,7 +13,10 @@ module OpenApiParser
     end
 
     def exists_in_path?(path)
-      path.include?(escaped_pointer)
+      # Trailing slash added to prevent false positives where the pointer
+      # matches a substring in the path for a different pointer.
+      # (e.g. "/definitions/PersonInfo" in "/definitions/PersonInfoResponse/schema")
+      path.include?("#{escaped_pointer}/")
     end
 
     def escaped_pointer

--- a/lib/open_api_parser/pointer.rb
+++ b/lib/open_api_parser/pointer.rb
@@ -13,9 +13,6 @@ module OpenApiParser
     end
 
     def exists_in_path?(path)
-      # Trailing slash added to prevent false positives where the pointer
-      # matches a substring in the path for a different pointer.
-      # (e.g. "/definitions/PersonInfo" in "/definitions/PersonInfoResponse/schema")
       path.include?("#{escaped_pointer}/")
     end
 

--- a/lib/open_api_parser/version.rb
+++ b/lib/open_api_parser/version.rb
@@ -1,3 +1,3 @@
 module OpenApiParser
-  VERSION = "1.3.1".freeze
+  VERSION = "1.3.0-dev".freeze
 end

--- a/lib/open_api_parser/version.rb
+++ b/lib/open_api_parser/version.rb
@@ -1,3 +1,3 @@
 module OpenApiParser
-  VERSION = "1.3.0-dev".freeze
+  VERSION = "1.3.1".freeze
 end

--- a/spec/open_api_parser/specification_spec.rb
+++ b/spec/open_api_parser/specification_spec.rb
@@ -3,11 +3,29 @@ require "spec_helper"
 RSpec.describe OpenApiParser::Specification do
   describe "self.resolve" do
     context "valid specification" do
-      it "resolves successfully" do
-        path = File.expand_path("../../resources/valid_spec.yaml", __FILE__)
-        specification = OpenApiParser::Specification.resolve(path)
+      let(:path) { File.expand_path("../../resources/valid_spec.yaml", __FILE__) }
+      let(:specification) { OpenApiParser::Specification.resolve(path) }
 
+      it "resolves successfully" do
         expect(specification.raw.fetch("swagger")).to eq("2.0")
+      end
+
+      it "properly resolves matching substring references" do
+        expanded_info_response = {
+          "type" => "object",
+          "properties" => {
+            "info" => {
+              "type" => "object",
+              "properties" => {
+                "name" => {
+                  "type" => "string"
+                }
+              }
+            }
+          }
+        }
+
+        expect(specification.raw.fetch("definitions").fetch("personInfoResponse")).to eq(expanded_info_response)
       end
     end
 

--- a/spec/resources/valid_spec.yaml
+++ b/spec/resources/valid_spec.yaml
@@ -39,6 +39,18 @@ definitions:
       name:
         type: string
 
+  personInfo:
+    type: object
+    properties:
+      name:
+        type: string
+
+  personInfoResponse:
+    type: object
+    properties:
+      info:
+        $ref: '#/definitions/personInfo'
+
   searchResponse:
     type: object
     required:
@@ -162,7 +174,7 @@ paths:
         200:
           description: Valid get person
           schema:
-            $ref: "#/definitions/validResponse"
+            $ref: "#/definitions/personInfoResponse"
         default:
           description: Error response
           schema:


### PR DESCRIPTION
A bug was introduced by https://github.com/braintree/open_api_parser/pull/10. If the pointer name was a substring of a previous pointer, the ref would be not be resolved.

For example, a definition called PersonInfoResponse would not resolve a ref to PersonInfo, because the `path.include?(escaped_pointer)` would return `true`. 

This fix adds a trailing slash so that the ref name is segmented and won't match the substring. Note that the path that is passed does not end with a "/", but the last part isn't involved in the matching. (e.g. The pointer `/definitions/personInfo` is checked inside the path `/paths//people/{id}/get/responses/200/schema/definitions/personInfoResponse/properties/info`)

@jfeltesse-mdsol @jcarres-mdsol @ykitamura-mdsol
